### PR TITLE
Make syntax match documentation

### DIFF
--- a/doc_source/intrinsic-function-reference-rules.md
+++ b/doc_source/intrinsic-function-reference-rules.md
@@ -105,7 +105,7 @@ Returns `true` if each member in a list of strings matches at least one value in
 ### Declaration<a name="fn-eachmemberin-declaration"></a>
 
 ```
-"Fn::EachMemberIn" : [[strings_to_check], strings_to_match]
+"Fn::EachMemberIn" : [[strings_to_check], [strings_to_match]]
 ```
 
 ### Parameters<a name="fn-eachmemberin-parameters"></a>


### PR DESCRIPTION
The description of EachMemberIn says that you need to lists, but the syntax definition only asks for one


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
