### PR TITLE
Update sync user baseline permissions

### DIFF
--- a/doc_source/baseline-permissions.md
+++ b/doc_source/baseline-permissions.md
@@ -27,6 +27,10 @@ The following section describes how to create the AWS Service Catalog Sync user 
    			"servicecatalog:DeleteProvisionedProductPlan",
    			"servicecatalog:DeleteProvisioningArtifact",
    			"servicecatalog:ListBudgetsForResource",
+            "servicecatalog:SearchProductsAsAdmin",
+            "servicecatalog:ListPortfoliosForProduct",
+            "servicecatalog:ListPrincipalsForPortfolio",
+            "servicecatalog:ListAcceptedPortfolioShares",            
    			"budgets:ViewBudget"
    		],
    		"Resource": "*"

--- a/doc_source/baseline-permissions.md
+++ b/doc_source/baseline-permissions.md
@@ -15,27 +15,27 @@ The following section describes how to create the AWS Service Catalog Sync user 
 1. Go to [Creating IAM Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html)\. Following the instructions there, create a policy called **SCConnectorAdmin** for ServiceNow administrators to delete AWS Service Catalog products in ServiceNow that do not have self\-service actions associated\. ServiceNow administrators can also view budgets associated to AWS Service Catalog portfolios and products\. Copy the following policy and paste it into **Policy Document**:
 
    ```
-   {
-   	"Version": "2012-10-17",
-   	"Statement": [{
-   		"Sid": "VisualEditor0",
-   		"Effect": "Allow",
-   		"Action": [
-   			"servicecatalog:DisassociateProductFromPortfolio",
-   			"servicecatalog:DeleteProduct",
-   			"servicecatalog:DeleteConstraint",
-   			"servicecatalog:DeleteProvisionedProductPlan",
-   			"servicecatalog:DeleteProvisioningArtifact",
-            "servicecatalog:ListBudgetsForResource",
-            "servicecatalog:SearchProductsAsAdmin",
-            "servicecatalog:ListPortfoliosForProduct",
-            "servicecatalog:ListPrincipalsForPortfolio",
-            "servicecatalog:ListAcceptedPortfolioShares",            
-            "budgets:ViewBudget"
-   		],
-   		"Resource": "*"
-   	}]
-   }
+      {
+         "Version": "2012-10-17",
+         "Statement": [{
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+               "servicecatalog:DisassociateProductFromPortfolio",
+               "servicecatalog:DeleteProduct",
+               "servicecatalog:DeleteConstraint",
+               "servicecatalog:DeleteProvisionedProductPlan",
+               "servicecatalog:DeleteProvisioningArtifact",
+               "servicecatalog:ListBudgetsForResource",
+               "servicecatalog:SearchProductsAsAdmin",
+               "servicecatalog:ListPortfoliosForProduct",
+               "servicecatalog:ListPrincipalsForPortfolio",
+               "servicecatalog:ListAcceptedPortfolioShares",            
+               "budgets:ViewBudget"
+            ],
+            "Resource": "*"
+         }]
+      }
    ```
 
 1. Go to [Creating an IAM User in Your AWS Account](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html)\. Following the instructions there, create a sync user \(that is, SCSyncUser\)\. The user needs programmatic and AWS Management Console access to follow the Connector for ServiceNow installation instructions\.

--- a/doc_source/baseline-permissions.md
+++ b/doc_source/baseline-permissions.md
@@ -31,7 +31,7 @@ The following section describes how to create the AWS Service Catalog Sync user 
             "servicecatalog:ListPortfoliosForProduct",
             "servicecatalog:ListPrincipalsForPortfolio",
             "servicecatalog:ListAcceptedPortfolioShares",            
-   			"budgets:ViewBudget"
+            "budgets:ViewBudget"
    		],
    		"Resource": "*"
    	}]

--- a/doc_source/baseline-permissions.md
+++ b/doc_source/baseline-permissions.md
@@ -26,7 +26,7 @@ The following section describes how to create the AWS Service Catalog Sync user 
    			"servicecatalog:DeleteConstraint",
    			"servicecatalog:DeleteProvisionedProductPlan",
    			"servicecatalog:DeleteProvisioningArtifact",
-   			"servicecatalog:ListBudgetsForResource",
+            "servicecatalog:ListBudgetsForResource",
             "servicecatalog:SearchProductsAsAdmin",
             "servicecatalog:ListPortfoliosForProduct",
             "servicecatalog:ListPrincipalsForPortfolio",


### PR DESCRIPTION
**Service Catalog Sync User Baseline Permissions Missing**

The service catalog sync user requires these additional permissions to operate, otherwise the connector results in errors as confirmed in a sandbox deployment:

{"__type":"AccessDeniedException","Message":"User: arn:aws:iam::645700315043:user/SCSyncUser is not authorized to perform: servicecatalog:ListAcceptedPortfolioShares on resource: arn:aws:servicecatalog:us-east-1:645700315043:*/*"}

{"__type":"AccessDeniedException","Message":"User: arn:aws:iam::645700315043:user/SCSyncUser is not authorized to perform: servicecatalog:ListPrincipalsForPortfolio on resource: arn:aws:catalog:us-east-1:645700315043:portfolio/port-5elbmihdvmj4k"}

{"__type":"AccessDeniedException","Message":"User: arn:aws:iam::645700315043:user/SCSyncUser is not authorized to perform: servicecatalog:ListPortfoliosForProduct on resource: arn:aws:catalog:us-east-1:645700315043:product/prod-xqixffzmcppts"}

Additionally, the permission "servicecatalog:SearchProductsAsAdmin" is required in order to use the **Validate** action as documented on configure-snow.md:192

Please note that these permissions are also missing from the cloudformation template that automatically deploys this user:

https://servicecatalogconnector.s3.amazonaws.com/SC_ConnectorForServiceNowv2.3.3+-AWS_Configurations_final.json



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
