### PR TITLE
Adding the word set after stack in the using-stacksets

### DIFF
--- a/doc_source/using-stacksets.md
+++ b/doc_source/using-stacksets.md
@@ -7,7 +7,7 @@ You can use AWS CloudFormation StackSets to launch AWS Service Catalog products 
 
 ## Stack sets vs\. stack instances<a name="stacksets-vs-stack-instances"></a>
 
-A *stack* lets you create stacks in AWS accounts across regions by using a single AWS CloudFormation template\.
+A *stack set* lets you create stacks in AWS accounts across regions by using a single AWS CloudFormation template\.
 
 A *stack instance* refers to a stack in a target account within a region and is associated with only one stack set\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding the word `set` in the sentence 
> A *stack set* lets you create stacks in AWS accounts across regions by using a single AWS CloudFormation template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
