### PR TITLE
Update configure-sc.md

### DIFF
--- a/doc_source/configure-sc.md
+++ b/doc_source/configure-sc.md
@@ -14,7 +14,7 @@ After you create two IAM users with baseline permissions in each account, the ne
 **Note**  
 The AWS configuration design requires each AWS Service Catalog product to have a launch constraint\. Failure to follow this step could result in an “Unable to Retrieve Parameter” message in the ServiceNow Service Catalog\. 
 
-1. Add the SnowEndUser IAM role to the AWS Service Catalog portfolio\. For additional user access instructions, see [Granting Access to Users](catalogs_portfolios_users.md)\. 
+1. Add the SnowEndUser IAM user to the AWS Service Catalog portfolio\. For additional user access instructions, see [Granting Access to Users](catalogs_portfolios_users.md)\. 
 
 **Note**  
  The AWS configuration design requires each AWS Service Catalog product to have either a launch constraint or a stack set constraint\. Failure to follow this step could result in an “Unable to Retrieve Parameter” error in the ServiceNow Service Catalog\. 


### PR DESCRIPTION
changed "Add the SnowEndUser IAM role to the AWS Service Catalog portfolio" to "Add the SnowEndUser IAM user to the AWS Service Catalog portfolio"

*Issue #, if available:*
SnowEndUser is an AWS IAM "user" created in the preceding page and not a "role"
*Description of changes:*
change text role to user

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
