### PR TITLE
add missing documentation for launch roles and launch constrains

### DIFF
--- a/doc_source/getstarted-deploy.md
+++ b/doc_source/getstarted-deploy.md
@@ -14,3 +14,32 @@ If you haven't created an IAM group for the endusers, see [Grant Permissions to 
 1. On the **Groups** tab, select the checkbox for the IAM group for the end users\.
 
 1. Choose **Add Access**\.
+
+**Working with launch roles and launch constraints**
+
+When you configure a launch role for a launch constraint, you must use this string for `s3:GetObject`:
+
+`"s3:ExistingObjectTag/servicecatalog:provisioning":"true"`.
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:ExistingObjectTag/servicecatalog:provisioning": "true"
+                }
+            }
+        }
+    ]
+}
+```
+
+
+

--- a/doc_source/getstarted-deploy.md
+++ b/doc_source/getstarted-deploy.md
@@ -17,7 +17,7 @@ If you haven't created an IAM group for the endusers, see [Grant Permissions to 
 
 **Working with launch roles and launch constraints**
 
-When you configure a launch role for a launch constraint, you must use this string for `s3:GetObject`:
+When you configure a launch role for a launch constraint, you must use add this string for `s3:GetObject` in your IAM role policy:
 
 `"s3:ExistingObjectTag/servicecatalog:provisioning":"true"`.
 


### PR DESCRIPTION

*Description of changes:*
I was missing this piece of documentation in the general available documentation for launch roles and launch constrains for Service Catalog. I ended up scanning the SC pdf and found it on page 57 https://docs.aws.amazon.com/servicecatalog/latest/adminguide/service-catalog-ag.pdf 

I think it would be good that add it to the general documentation for others to use.
